### PR TITLE
Add WPCS and PHP_CodeSniffer Standards Composer Installer as depencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "nextpress/nextpresscs",
+    "type": "phpcodesniffer-standard",
     "description": "NextPress Coding Standards",
     "minimum-stability": "stable",
     "authors": [
@@ -11,6 +12,8 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "squizlabs/php_codesniffer": "^3.3.1"
+        "squizlabs/php_codesniffer": "^3.3.1",
+        "wp-coding-standards/wpcs": "^2.0.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,49 +1,29 @@
 # NextPress Coding Standards
 
-The goal of this repo is to provide the necessary sniffs for our custom coding standards, making sure that all NextPress products maintain a consitent codebase.
+The goal of this repo is to provide the necessary sniffs for our custom coding standards, making sure that all NextPress products maintain a consistent codebase.
 
 ## Installation
 
-### Installing PHPCS
-To install our coding standards, first we need to make sure we have PHPCS installed and running on your machine. The easist way of doing this is installing it globally via Composer:
+Our coding standards rely on PHPCS and WordPress Coding Standards. The easiest way to get everything up and running is installing this package globally via Composer:
 ```
-composer global require "squizlabs/php_codesniffer=*"
-```
-
-### Installing WordPress Coding Standards
-After you install PHPCS, you need to install WordPress Code Standards. Our custom code standards rely heavily on the standarts set by WordPress, so they are a pre-requisite before you get up and running with our own CS.
-
-To install WordPress coding standards, clone their repo on a directory of your choosing. ~/utilities, for example:
-```
-cd
-mkdir utilities
-cd utilities
-git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wpcs
-```
-This will place the WordPress coding standards on the wpcs directory inside your utilities folder.
-
-### Installing NextPress Coding Standards
-The procedure to install the NextPress coding standards is the same. You close this repo to your utilities folder (or other folder of your choosing):
-```
-cd
-cd utilities
-git clone -b master https://github.com/next-press/NextPress-Coding-Standards.git nextpresscs
-```
-This will place the NextPress coding standards on the nextpresscs directory inside your utilities folder.
-
-### Telling PHPCS to use our newly added standards
-Now that you have both WordPress CS and NextPress CS inatalled on your machine, you simply need to tell phpcs to use them. To do that, open a terminal window and run the code below:
-```
-phpcs --config-set installed_paths /Users/youruser/utilities/wpcs,/Users/youruser/utilities/nextpresscs
+composer global require "nextpress/nextpresscs:dev-master"
 ```
 
-To confirm that the new Code Standards where installed, run:
+This command will install PHP_CodeSniffer, WPCS, our coding standard, and PHP_CodeSniffer Standards Composer Installer, a composer package that automatically sets the PHPCS `installed_paths` config.
+
+### Making `phpcs` available
+
+By default, `phpcs` binary will be available at `~/.config/composer/vendor/bin` (on Linux machines). To make it available anywhere in the command line, it is necessary to add that folder to the env `$PATH` variable.
+
+On linux machines it is possible adding this line in the end of the `~/.bashrc` file:
 ```
-phpcs -i
+export PATH="$HOME/.config/composer/vendor/bin/:$PATH"
 ```
-You should see WordPress-Core, WordPress-Docs, WordPress-Extra and NextPress on that list.
 
 # Changelog
+
+### Version 0.0.2
+* Changed: Global install via composer with PHP_CodeSniffer Standards Composer Installer;
 
 ### Version 0.0.1
 * Added: Initial version of the Coding Standards;


### PR DESCRIPTION
This PR main objective is to make the installation and update processes easier, keeping everything under Composer.

## How to test it
I suggest you remove the globally installed PHP_CodeSniffer package with
`composer global remove squizlabs/php_codesniffer`

and then globally install this package alone with
`composer global require nextpress/nextpresscs:dev-phpcs-composer-installer-compatibility`

Installing this package globally will (re)install _PHP_CodeSniffer_, _WordPress Coding Standards_, and _PHP_CodeSniffer Standards Composer Installer_, the package responsible to automatically link WPCS and NextPress CS to PHPCS.

After merging this PR, we should change `nextpress/nextpresscs` version to `dev-master`.